### PR TITLE
Moved the binary download to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk update && \
   apk add ca-certificates && \
   rm -rf /var/cache/apk/*
 
-ADD cf /bin/
+ENV CF_VERSION 6.19.0
+RUN wget -qO - "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_VERSION}" | tar -xz -C /bin/
+
 ADD drone-cloudfoundry /bin/
 ENTRYPOINT ["/bin/drone-cloudfoundry"]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ clean:
 	go clean -i ./...
 
 deps:
-	go get -d github.com/cloudfoundry/cli/main
 	go get -t ./...
 
 fmt:
@@ -26,12 +25,10 @@ test:
 	@for PKG in $(PACKAGES); do go test -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || exit 1; done;
 
 docker:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o cf github.com/cloudfoundry/cli/main
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-s -w $(LDFLAGS)'
 	docker build --rm -t $(IMAGE) .
 
 $(EXECUTABLE): $(wildcard *.go)
-	go build -o cf github.com/cloudfoundry/cli/main
 	go build -ldflags '-s -w $(LDFLAGS)'
 
 build: $(EXECUTABLE)


### PR DESCRIPTION
For the terraform plugin we are downloading the required binary within
the dockerfile, so I have done it here as well to make the build even
easier.

Signed-off-by: Thomas Boerger tboerger@suse.de
