### PR TITLE
Install cloudfoundry-cli from new package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-# Docker image for the Drone Cloud Foundry plugin
+# Docker image for the Drone Cloudfoundry plugin
 #
 #     cd $GOPATH/src/github.com/drone-plugins/drone-cloudfoundry
 #     make deps build docker
 
-FROM alpine:3.2
+FROM alpine:3.4
 
-RUN apk update && \
-  apk add ca-certificates && \
+RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" | tee -a /etc/apk/repositories && \
+  apk -U add \
+    ca-certificates \
+    git \
+    cloudfoundry-cli@testing && \
   rm -rf /var/cache/apk/*
-
-ENV CF_VERSION 6.19.0
-RUN wget -qO - "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_VERSION}" | tar -xz -C /bin/
 
 ADD drone-cloudfoundry /bin/
 ENTRYPOINT ["/bin/drone-cloudfoundry"]


### PR DESCRIPTION
To avoid the download of untrusted packages I have updated the
Dockerfile to use a package provided by alpine testing repository.
